### PR TITLE
[codex] Fix create git commit environment

### DIFF
--- a/.changeset/quiet-files-pay.md
+++ b/.changeset/quiet-files-pay.md
@@ -1,0 +1,5 @@
+---
+"patchworks": patch
+---
+
+Prevent `patchworks create` from failing when the shell environment contains git editor, pager, askpass, or config injection variables blocked by newer simple-git releases.

--- a/src/commands/__tests__/create.test.ts
+++ b/src/commands/__tests__/create.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { createPatchworksCommitEnv } from "../create";
+
+describe("createPatchworksCommitEnv", () => {
+  it("removes git env hooks blocked by simple-git", () => {
+    const commitEnv = createPatchworksCommitEnv({
+      EDITOR: "code",
+      GIT_ASKPASS: "/tmp/askpass",
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "core.pager",
+      GIT_CONFIG_VALUE_0: "less",
+      GIT_EDITOR: "vim",
+      GIT_EXTERNAL_DIFF: "diff-tool",
+      GIT_PAGER: "cat",
+      GIT_SEQUENCE_EDITOR: "vim",
+      GIT_SSH_COMMAND: "ssh -i key",
+      PAGER: "less",
+      PREFIX: "/tmp/prefix",
+      SSH_ASKPASS: "/tmp/ssh-askpass",
+      PATH: "/usr/bin",
+      HOME: "/Users/test",
+      GITHUB_TOKEN: "token",
+      GIT_AUTHOR_NAME: "Local User",
+      GIT_AUTHOR_EMAIL: "local@example.com",
+    });
+
+    expect(commitEnv).not.toHaveProperty("EDITOR");
+    expect(commitEnv).not.toHaveProperty("GIT_ASKPASS");
+    expect(commitEnv).not.toHaveProperty("GIT_CONFIG_COUNT");
+    expect(commitEnv).not.toHaveProperty("GIT_CONFIG_KEY_0");
+    expect(commitEnv).not.toHaveProperty("GIT_CONFIG_VALUE_0");
+    expect(commitEnv).not.toHaveProperty("GIT_EDITOR");
+    expect(commitEnv).not.toHaveProperty("GIT_EXTERNAL_DIFF");
+    expect(commitEnv).not.toHaveProperty("GIT_PAGER");
+    expect(commitEnv).not.toHaveProperty("GIT_SEQUENCE_EDITOR");
+    expect(commitEnv).not.toHaveProperty("GIT_SSH_COMMAND");
+    expect(commitEnv).not.toHaveProperty("PAGER");
+    expect(commitEnv).not.toHaveProperty("PREFIX");
+    expect(commitEnv).not.toHaveProperty("SSH_ASKPASS");
+    expect(commitEnv.PATH).toBe("/usr/bin");
+    expect(commitEnv.HOME).toBe("/Users/test");
+    expect(commitEnv.GITHUB_TOKEN).toBe("token");
+    expect(commitEnv.GIT_AUTHOR_NAME).toBe("Patchworks");
+    expect(commitEnv.GIT_AUTHOR_EMAIL).toBe("bot@patchworks.dev");
+    expect(commitEnv.GIT_COMMITTER_NAME).toBe("Patchworks");
+    expect(commitEnv.GIT_COMMITTER_EMAIL).toBe("bot@patchworks.dev");
+  });
+});

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -11,6 +11,55 @@ import * as tmp from "tmp";
 // Configure tmp to automatically clean up on process exit
 tmp.setGracefulCleanup();
 
+const unsafeGitEnvKeys = new Set([
+  "EDITOR",
+  "GIT_ASKPASS",
+  "GIT_CONFIG",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_SYSTEM",
+  "GIT_EDITOR",
+  "GIT_EXEC_PATH",
+  "GIT_EXTERNAL_DIFF",
+  "GIT_PAGER",
+  "GIT_PROXY_COMMAND",
+  "GIT_SEQUENCE_EDITOR",
+  "GIT_SSH",
+  "GIT_SSH_COMMAND",
+  "GIT_TEMPLATE_DIR",
+  "PAGER",
+  "PREFIX",
+  "SSH_ASKPASS",
+]);
+
+function isUnsafeGitEnvKey(key: string) {
+  const normalizedKey = key.toUpperCase();
+  return (
+    unsafeGitEnvKeys.has(normalizedKey) ||
+    /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(normalizedKey)
+  );
+}
+
+export function createPatchworksCommitEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const commitEnv = { ...env };
+
+  for (const key of Object.keys(commitEnv)) {
+    if (isUnsafeGitEnvKey(key)) {
+      delete commitEnv[key];
+    }
+  }
+
+  return {
+    ...commitEnv,
+    GIT_AUTHOR_NAME: "Patchworks",
+    GIT_AUTHOR_EMAIL: "bot@patchworks.dev",
+    GIT_COMMITTER_NAME: "Patchworks",
+    GIT_COMMITTER_EMAIL: "bot@patchworks.dev",
+  };
+}
+
 export const createCommand = command({
   name: "create",
   desc: "Clone a template repository and initialize it for patchworks",
@@ -153,13 +202,7 @@ export const createCommand = command({
       // Add all files and create initial commit with explicit author and committer settings
       await git.add(".");
 
-      const commitEnv = {
-        ...process.env,
-        GIT_AUTHOR_NAME: "Patchworks",
-        GIT_AUTHOR_EMAIL: "bot@patchworks.dev",
-        GIT_COMMITTER_NAME: "Patchworks",
-        GIT_COMMITTER_EMAIL: "bot@patchworks.dev",
-      };
+      const commitEnv = createPatchworksCommitEnv();
 
       await git.env(commitEnv).commit("Initial commit");
 


### PR DESCRIPTION
Fixes patchworks create failures when shell env includes git editor, pager, askpass, or config variables blocked by newer simple-git releases.\n\nValidation: pnpm test:unit; exact bunx patchworks@latest create command verified locally after linking/cache patch.