### PR TITLE
[codex] Switch npm release to trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -20,9 +25,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile
+
+      - run: npm install -g npm@latest
 
       - uses: changesets/action@v1
         id: changesets
@@ -31,4 +38,3 @@ jobs:
           version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Changes
- Grants the release workflow `id-token: write` so npm can use GitHub Actions OIDC trusted publishing.
- Keeps `contents: write` and `pull-requests: write` for Changesets version PRs/commits.
- Configures `actions/setup-node` with the npm registry URL.
- Installs the latest npm CLI before `changeset publish`, then removes the long-lived `NPM_TOKEN` from the publish environment.

## Why
The publish run failed with npm `E404 Not Found` while trying to publish `patchworks@0.1.3`, which is the error npm returns when the registry request is not authorized for that package. Moving to trusted publishing avoids a stale or incorrectly scoped npm token and lets npm authorize the exact GitHub Actions workflow through OIDC.

## Required npm setup
Configure the `patchworks` package on npmjs.com with a Trusted Publisher:
- Provider: GitHub Actions
- Organization/user: `ludicroushq`
- Repository: `patchworks`
- Workflow filename: `release.yaml`
- Allowed action: `npm publish`

## Validation
- `pnpm run ci:test:pretty`
- `git diff --check`
